### PR TITLE
typescript sdk version bumps

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -25,7 +25,7 @@
   "license": "ISC",
   "dependencies": {
     "@humeai/voice-embed": "workspace:*",
-    "hume": "^0.11.4",
+    "hume": "^0.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.1-beta.1",
+  "version": "0.2.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.1-beta.1",
+  "version": "0.2.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -35,7 +35,7 @@
     "vitest": "^3.1.2"
   },
   "dependencies": {
-    "hume": "0.11.4",
+    "hume": "0.12.0",
     "zod": "^3.22.4"
   },
   "browserslist": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.1-beta.1",
+  "version": "0.2.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -27,7 +27,7 @@
   "license": "ISC",
   "dependencies": {
     "date-fns": "^3.6.0",
-    "hume": "0.11.5-beta.1",
+    "hume": "0.12.0",
     "meyda": "^5.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,8 +194,8 @@ importers:
   packages/embed:
     dependencies:
       hume:
-        specifier: 0.11.4
-        version: 0.11.4
+        specifier: 0.12.0
+        version: 0.12.0
       zod:
         specifier: ^3.22.4
         version: 3.23.8
@@ -228,8 +228,8 @@ importers:
         specifier: workspace:*
         version: link:../embed
       hume:
-        specifier: ^0.11.4
-        version: 0.11.4
+        specifier: ^0.12.0
+        version: 0.12.0
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -295,8 +295,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       hume:
-        specifier: 0.11.5-beta.1
-        version: 0.11.5-beta.1
+        specifier: 0.12.0
+        version: 0.12.0
       meyda:
         specifier: ^5.6.2
         version: 5.6.3(rollup@4.40.1)
@@ -3123,8 +3123,8 @@ packages:
   hume@0.11.4:
     resolution: {integrity: sha512-DFS7qJhKWF3Cbos0cgiR6DLXYW17yJi8PpC0KSmtUqR2zr05CnbowYjVF2NXhWDzvKuJnARBeKu5AiNTmaO97A==}
 
-  hume@0.11.5-beta.1:
-    resolution: {integrity: sha512-T7nA7fhv2jOwO1ELKI+cExRzWe8o1fueYppc3BTJUw6//0wUU3ye+Y7gPMiCYOCU8mUrzlZgynXmZcNcXEqZ/Q==}
+  hume@0.12.0:
+    resolution: {integrity: sha512-VxHYP52VxVoUkFXoG4/lntkVWBZXXegKG9JsLL88BGuVqrc9wQOTUShk6BRSmLucDLDcv6kKcZ42nERkFSW7jQ==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -7962,7 +7962,7 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  hume@0.11.5-beta.1:
+  hume@0.12.0:
     dependencies:
       form-data: 4.0.0
       form-data-encoder: 4.0.2


### PR DESCRIPTION
Just `pnpm install hume@latest` in each of the packages and then editing package.json to remove the `-beta` from the package version.