### PR TITLE
include interim user messages in the `messages` array

### DIFF
--- a/examples/next-app/components/ChatConnected.tsx
+++ b/examples/next-app/components/ChatConnected.tsx
@@ -236,7 +236,9 @@ export const ChatConnected = () => {
               if (message.type === 'user_message') {
                 return (
                   <div key={message.receivedAt.toISOString()}>
-                    <div className="text-xs uppercase">User</div>
+                    <div className="text-xs uppercase">
+                      User ({String(message.interim)})
+                    </div>
                     <div>{message.message.content}</div>
                   </div>
                 );
@@ -246,7 +248,7 @@ export const ChatConnected = () => {
           </div>
         </div>
 
-        <div>
+        {/* <div>
           <div className={'text-sm font-medium uppercase'}>
             Last assistant message
           </div>
@@ -287,7 +289,7 @@ export const ChatConnected = () => {
             value={JSON.stringify(lastAssistantProsodyMessage)}
             readOnly
           ></textarea>
-        </div>
+        </div> */}
       </div>
     </div>
   );

--- a/examples/next-app/components/ChatConnected.tsx
+++ b/examples/next-app/components/ChatConnected.tsx
@@ -243,12 +243,16 @@ export const ChatConnected = () => {
                   </div>
                 );
               }
-              return null;
+              return (
+                <div key={message.receivedAt.toISOString()}>
+                  {JSON.stringify(message)}
+                </div>
+              );
             })}
           </div>
         </div>
 
-        {/* <div>
+        <div>
           <div className={'text-sm font-medium uppercase'}>
             Last assistant message
           </div>
@@ -289,7 +293,7 @@ export const ChatConnected = () => {
             value={JSON.stringify(lastAssistantProsodyMessage)}
             readOnly
           ></textarea>
-        </div> */}
+        </div>
       </div>
     </div>
   );

--- a/examples/next-app/components/ChatConnected.tsx
+++ b/examples/next-app/components/ChatConnected.tsx
@@ -235,7 +235,13 @@ export const ChatConnected = () => {
               }
               if (message.type === 'user_message') {
                 return (
-                  <div key={message.receivedAt.toISOString()}>
+                  <div
+                    key={
+                      message.receivedAt.toISOString() +
+                      message.message.content +
+                      JSON.stringify(message.time)
+                    }
+                  >
                     <div className="text-xs uppercase">
                       User ({String(message.interim)})
                     </div>

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.1",
+  "version": "0.2.2-beta.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.2-beta.1",
+  "version": "0.2.2-beta.3",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.2-beta.3",
+  "version": "0.2.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.2-beta.1",
+  "version": "0.2.2-beta.3",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.2-beta.3",
+  "version": "0.2.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.1",
+  "version": "0.2.2-beta.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.1",
+  "version": "0.2.2-beta.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.2-beta.2",
+  "version": "0.2.2-beta.3",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.2-beta.3",
+  "version": "0.2.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.2-beta.1",
+  "version": "0.2.2-beta.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/useMessages.test.ts
+++ b/packages/react/src/lib/useMessages.test.ts
@@ -268,7 +268,7 @@ describe('useMessages hook', () => {
     expect(hook.result.current.lastUserMessage).toBeNull();
   });
 
-  it('should not add interim user messages to `messages` or `lastUserMessage`, but does call `sendMessageToParent`', () => {
+  it('should not set interim user messages as `lastUserMessage`, but does call `sendMessageToParent`', () => {
     act(() => {
       hook.result.current.onMessage({
         ...userMessage,
@@ -277,12 +277,135 @@ describe('useMessages hook', () => {
       });
     });
 
-    expect(hook.result.current.messages).toMatchObject([]);
     expect(hook.result.current.lastUserMessage).toBe(null);
     expect(sendMessageToParent).toHaveBeenCalledWith({
       ...userMessage,
       interim: true,
       receivedAt: new Date(1),
     });
+  });
+
+  it('replaces interim user messages until a non-interim message is received', () => {
+    const interimMessage1 = {
+      ...userMessage,
+      message: {
+        ...userMessage.message,
+        content: 'interim message 1',
+      },
+      interim: true,
+      receivedAt: new Date(1),
+    };
+    act(() => {
+      hook.result.current.onMessage(interimMessage1);
+    });
+
+    expect(hook.result.current.messages).toMatchObject([
+      expect.objectContaining(interimMessage1),
+    ]);
+
+    const interimMessage2 = {
+      ...userMessage,
+      message: {
+        ...userMessage.message,
+        content: 'interim message 2',
+      },
+      interim: true,
+      receivedAt: new Date(1),
+    };
+    act(() => {
+      hook.result.current.onMessage(interimMessage2);
+    });
+
+    expect(hook.result.current.messages).toMatchObject([
+      expect.objectContaining(interimMessage2),
+    ]);
+    expect(hook.result.current.messages).not.toMatchObject([
+      expect.objectContaining(interimMessage1),
+    ]);
+
+    const finalMessage = {
+      ...userMessage,
+      message: {
+        ...userMessage.message,
+        content: 'final message',
+      },
+      interim: false,
+      receivedAt: new Date(2),
+    };
+    act(() => {
+      hook.result.current.onMessage(finalMessage);
+    });
+
+    expect(hook.result.current.messages).not.toMatchObject([
+      expect.objectContaining(interimMessage2),
+    ]);
+    expect(hook.result.current.messages).not.toMatchObject([
+      expect.objectContaining(interimMessage1),
+    ]);
+    expect(hook.result.current.messages).toMatchObject([
+      expect.objectContaining(finalMessage),
+    ]);
+  });
+
+  it('does no replacements if there are no interim messages', () => {
+    const message1 = {
+      ...userMessage,
+      message: {
+        ...userMessage.message,
+        content: 'message 1',
+      },
+      interim: false,
+      receivedAt: new Date(1),
+    };
+    act(() => {
+      hook.result.current.onMessage(message1);
+    });
+
+    expect(hook.result.current.messages).toMatchObject([
+      expect.objectContaining(message1),
+    ]);
+
+    const message2 = {
+      ...userMessage,
+      message: {
+        ...userMessage.message,
+        content: 'interim message 2',
+      },
+      interim: false,
+      receivedAt: new Date(1),
+    };
+    act(() => {
+      hook.result.current.onMessage(message2);
+    });
+
+    expect(hook.result.current.messages[0]).toMatchObject(
+      expect.objectContaining(message1),
+    );
+    expect(hook.result.current.messages[1]).toMatchObject(
+      expect.objectContaining(message2),
+    );
+
+    const finalMessage = {
+      ...userMessage,
+      message: {
+        ...userMessage.message,
+        content: 'final message',
+      },
+      interim: false,
+      receivedAt: new Date(2),
+    };
+    act(() => {
+      hook.result.current.onMessage(finalMessage);
+    });
+
+    expect(hook.result.current.messages[0]).toMatchObject(
+      expect.objectContaining(message1),
+    );
+    expect(hook.result.current.messages[1]).toMatchObject(
+      expect.objectContaining(message2),
+    );
+    expect(hook.result.current.messages[2]).toMatchObject(
+      expect.objectContaining(finalMessage),
+    );
   });
 });

--- a/packages/react/src/lib/useMessages.test.ts
+++ b/packages/react/src/lib/useMessages.test.ts
@@ -269,7 +269,7 @@ describe('useMessages hook', () => {
     expect(hook.result.current.lastUserMessage).toBeNull();
   });
 
-  it('should not set interim user messages as `lastUserMessage`, but does call `sendMessageToParent`', () => {
+  it('should not assign interim user messages to `lastUserMessage`, but does call `sendMessageToParent`', () => {
     act(() => {
       hook.result.current.onMessage({
         ...userMessage,

--- a/packages/react/src/lib/useMessages.test.ts
+++ b/packages/react/src/lib/useMessages.test.ts
@@ -410,7 +410,7 @@ describe('useMessages hook', () => {
     );
   });
 
-  it.only('always pushes interim user messages to the end of the messages array', () => {
+  it('always pushes interim user messages to the end of the messages array', () => {
     const interimMessage = {
       ...userMessage,
       interim: true,

--- a/packages/react/src/lib/useMessages.ts
+++ b/packages/react/src/lib/useMessages.ts
@@ -103,13 +103,16 @@ export const useMessages = ({
               }
             }
             if (mostRecentUserMessage?.interim === true) {
-              const nextMessages = prev.map((m, idx) => {
+              const nextMessages = prev.filter((m, idx) => {
                 if (idx === mostRecentUserMessageIndex) {
-                  return message;
+                  return false;
                 }
-                return m;
+                return true;
               });
-              return keepLastN(messageHistoryLimit, nextMessages);
+              return keepLastN(
+                messageHistoryLimit,
+                nextMessages.concat([message]),
+              );
             }
             return keepLastN(messageHistoryLimit, prev.concat([message]));
           });


### PR DESCRIPTION
Supports adding interim user messages to the messages array so that the end user can display in-progress user message transcriptions.

1. When adding a user message to the array...
  * if there is an existing interim user message, replace it with the current user message.
  * otherwise, simply add the current message to the end of the array.
3. When adding any other message type...
  * if there is an existing interim user message, move the existing interim message to the end of the array and insert the current message in the penultimate position.
  * if there is no existing interim user message, push the current message to the end of the array